### PR TITLE
fix: Add missing z85pad mode to the TypeScript version

### DIFF
--- a/lib/base85.d.ts
+++ b/lib/base85.d.ts
@@ -1,6 +1,6 @@
 import type { Buffer } from 'buffer';
 
-declare type Base85Encoding = 'z85' | 'ascii85' | 'ipv6';
+declare type Base85Encoding = 'z85' | 'z85pad' | 'ascii85' | 'ipv6';
 
 export function encode(
   data: Buffer | string,


### PR DESCRIPTION
The README mentions that there is a `z85pad` mode that can be used to skip the Z85 length checks, but it's not available in the TypeScript version due to the `z85pad` version missing.

Add it to the declaration file.